### PR TITLE
Dialogs: Fix confirm and cancel hotkeys and focus text field

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+[*.lua]
+charset = utf-8
+indent_size = 2
+indent_style = space
+end_of_line = lf

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,0 @@
-[*.lua]
-charset = utf-8
-indent_size = 2
-indent_style = space
-end_of_line = lf

--- a/control.lua
+++ b/control.lua
@@ -293,7 +293,6 @@ script.on_event(defines.events.on_gui_click, function(event)
     end
     local data = split(elementName,"_")
     local telaportLocIndex = tonumber(data[2])
-    setPlayerWindowOpenNamePrefix(player,"TelaportRename")
     createTelaPortRenameWindow(player,telaportLocIndex,getTelaporter(player , telaportLocIndex)[1])
    
   elseif elementName == "TelaportRename_Cancel" then
@@ -349,9 +348,8 @@ script.on_event(defines.events.on_gui_click, function(event)
   elseif beginsWith(elementName, "teleportCategory_") then 
     local data = split(elementName,"_")
     local categoryName = data[2]
-    if categoryName == getPlayerCategory(player) and (player.gui.center.TelaportCategorySettingWindow == nill)then 
-      createCategorySettingWindow(player.gui.center,categoryName)
-      setPlayerWindowOpenNamePrefix(player, "TelaportCategorySetting")
+    if categoryName == getPlayerCategory(player) and (player.gui.center.TelaportCategorySettingWindow == nil) then 
+      createCategorySettingWindow(player,categoryName)
       return
     end
     if categoryName ~= getPlayerCategory(player) then
@@ -360,45 +358,10 @@ script.on_event(defines.events.on_gui_click, function(event)
     end
   
   elseif elementName == "TelaportCategorySetting_Cancel" then 
-    if player.gui.center.TelaportCategorySettingWindow ~= nill then
-      player.gui.center.TelaportCategorySettingWindow.destroy()
-      setPlayerWindowOpenNamePrefix(player, nil)
-    end
+    closeCategorySettingsWindow(player)
     
   elseif beginsWith(elementName, "TelaportCategorySetting_OK") then
-    local data = split(elementName,"_")
-    local CategoryCurrentName = data[3]
-    local newName = player.gui.center.TelaportCategorySettingWindow.TelaportCategorySettingText.text
-    newName = cleanupName(newName)
-    if newName ~= nil and newName ~= '' then
-      for i,category in ipairs(global.Categories) do
-        if category.name == newName then 
-          player.gui.center.TelaportCategorySettingWindow.destroy()
-          setPlayerWindowOpenNamePrefix(player, nil)
-          player.print("can't rename Category to a name that already exist")
-          return
-        end
-      end
-      for i,category in ipairs(global.Categories) do 
-        if category.name == CategoryCurrentName then 
-          category.name = newName
-        end
-      end
-      for i,telaportLoc in ipairs(global.TelaportLocations) do 
-        for x,category in ipairs(telaportLoc[6]) do 
-          if category.name == CategoryCurrentName then
-            category.name = newName
-          end
-        end
-      end
-      setPlayerCategory(player,newName)
-      player.gui.center.TelaportCategorySettingWindow.destroy()
-      setPlayerWindowOpenNamePrefix(player, nil)
-      recreateOpenWindows()
-    else
-      --alert that player can not input black string as category name
-      player.print("can't have a blank category name.")
-    end
+    onCategorySettingsConfirm(event)
     
   elseif beginsWith(elementName, "TelaportSetCategoryOpen_") then 
     if player.gui.center.TelaportSetCategoryWindow == nil then
@@ -439,29 +402,14 @@ script.on_event(defines.events.on_gui_click, function(event)
     
   elseif elementName == "teleportCategoryAdd" then
     if player.gui.center.TelaportCategoryAddWindow == nil then
-      createTelaportCategoryAddWindow(player.gui.center)
-      setPlayerWindowOpenNamePrefix(player , "TelaportCategoryAdd")
+      createTelaportCategoryAddWindow(player)
     end
   
-  elseif elementName == "TelaportCategoryAdd_Cancel" then 
-    if player.gui.center.TelaportCategoryAddWindow ~= nil then
-      player.gui.center.TelaportCategoryAddWindow.destroy()
-      setPlayerWindowOpenNamePrefix(player,nil)
-    end
+  elseif elementName == "TelaportCategoryAdd_Cancel" then
+    closeCategoryAddWindow(player)
   
   elseif elementName == "TelaportCategoryAdd_OK" then 
-    local categoryName = player.gui.center.TelaportCategoryAddWindow.TelaportCategoryAddText.text
-    if categoryName ~= nil and categoryName ~= '' then
-      if not categoryNameAllreadyExist(categoryName,player) then
-        addCategory(categoryName) 
-        recreateOpenWindows()
-        player.gui.center.TelaportCategoryAddWindow.destroy()
-        setPlayerWindowOpenNamePrefix(player,nil)
-      end
-    else 
-      --alert that player can not input black string as category name
-      player.print("can't have a blank category name.")
-    end
+    onCategoryAddConfirm(event)
     
   elseif beginsWith(elementName, "TelaportCategorySetting_Delete") then
     local data = split(elementName,"_")
@@ -483,8 +431,7 @@ script.on_event(defines.events.on_gui_click, function(event)
       end
     end
     --setPlayerCategory(player,newName)
-    player.gui.center.TelaportCategorySettingWindow.destroy()
-    setPlayerWindowOpenNamePrefix(player, nil)
+    closeCategorySettingsWindow(player)
   end
 end)
   
@@ -495,18 +442,18 @@ end
 
 
 function createTelaPortRenameWindow(player,TelportIndex,oldName)
-   local gui = player.gui.center;
-   local frame = gui.add({type="frame", name="TelaportRenameWindow", direction="vertical", caption="Teleport Location Rename", tags={teleportIndex=TelportIndex}})
-    frame.add({type="textfield", name="TelaportRenameText"})
-    frame.TelaportRenameText.text = oldName
-
-    local flow = frame.add({type="flow", name="TelaportRenameFlow", direction="horizontal"})
-    flow.add({type="button", name=createButtonName("TelaportRename_Cancel"), caption="Cancel"})
-    flow.add({type="button", name=createButtonName("TelaportRename_OK",TelportIndex) , caption="OK"})
-
-    player.opened = frame;
-    return frame
+  local gui = player.gui.center;
+  local frame = gui.add({type="frame", name="TelaportRenameWindow", direction="vertical", caption="Teleport Location Rename", tags={teleportIndex=TelportIndex}})
+  frame.add({type="textfield", name="TelaportRenameText"})
+  frame.TelaportRenameText.text = oldName
   
+  local flow = frame.add({type="flow", name="TelaportRenameFlow", direction="horizontal"})
+  flow.add({type="button", name=createButtonName("TelaportRename_Cancel"), caption="Cancel"})
+  flow.add({type="button", name=createButtonName("TelaportRename_OK",TelportIndex) , caption="OK"})
+  
+  setPlayerWindowOpenNamePrefix(player,"TelaportRename")
+  player.opened = frame;
+  return frame
 end
 
 function closeTelaPortRenameWindow(player)
@@ -518,15 +465,32 @@ function closeTelaPortRenameWindow(player)
 end
 
 script.on_event(defines.events.on_gui_closed, function(event)
-  player = game.players[event.player_index]
-  if event.element and event.element.valid and event.element.name == "TelaportRenameWindow" then
+  if not(event.element and event.element.valid) then
+    return
+  end
+
+  local player = game.players[event.player_index]
+
+  if event.element.name == "TelaportRenameWindow" then
     closeTelaPortRenameWindow(player)
+  elseif event.element.name == "TelaportCategoryAddWindow" then
+    closeCategoryAddWindow(player)
+  elseif event.element.name == "TelaportCategorySettingWindow" then
+    closeCategorySettingsWindow(player)
   end
 end)
 
 script.on_event(defines.events.on_gui_confirmed, function(event)
-  if event.element and event.element.valid and event.element.parent and event.element.parent.name == "TelaportRenameWindow" then
+  if not(event.element and event.element.valid and event.element.parent) then
+    return
+  end
+
+  if event.element.parent.name == "TelaportRenameWindow" then
     onRenameConfirm(event)
+  elseif event.element.parent.name == "TelaportCategoryAddWindow" then
+    onCategoryAddConfirm(event)
+  elseif event.element.parent.name == "TelaportCategorySettingWindow" then
+    onCategorySettingsConfirm(event)
   end
 end)
 
@@ -763,8 +727,9 @@ function getTelaportLocations( Category )
   return locations
 end
 
-function createCategorySettingWindow(gui,oldName)
-  local frame = gui.add({type="frame", name="TelaportCategorySettingWindow", direction="vertical", caption="Category Settings"})
+function createCategorySettingWindow(player,oldName)
+  local gui = player.gui.center;
+  local frame = gui.add({type="frame", name="TelaportCategorySettingWindow", direction="vertical", caption="Category Settings", tags={oldName=oldName}})
   frame.add({type="textfield", name="TelaportCategorySettingText"})
   frame.TelaportCategorySettingText.text = oldName
 
@@ -773,7 +738,57 @@ function createCategorySettingWindow(gui,oldName)
   flow.add({type="button", name=createButtonName("TelaportCategorySetting_Delete",oldName), caption="Delete"})
   flow.add({type="button", name=createButtonName("TelaportCategorySetting_OK",oldName) , caption="OK"})
 
+  setPlayerWindowOpenNamePrefix(player, "TelaportCategorySetting")
+  player.opened = frame
   return frame
+end
+
+function closeCategorySettingsWindow(player)
+  player.gui.center.TelaportCategorySettingWindow.destroy()
+  setPlayerWindowOpenNamePrefix(player, nil)
+  player.opened = nil
+end
+
+function onCategorySettingsConfirm(event)
+  local player = game.players[event.player_index]
+  local frame = player.gui.center.TelaportCategorySettingWindow
+  if frame == nil then
+    player.print("Could not find open settings window")
+    return
+  end
+  local CategoryCurrentName = frame.tags.oldName
+
+  local newName = frame.TelaportCategorySettingText.text
+  newName = cleanupName(newName)
+  if not (newName ~= nil and newName ~= '') then
+    --alert that player can not input black string as category name
+    player.print("Category name cannot be blank / empty")
+    return
+  end
+
+  for i,category in ipairs(global.Categories) do
+    if category.name == newName then
+      player.print("Can't rename Category to a name that already exist")
+      return
+    end
+  end
+
+  for i,category in ipairs(global.Categories) do
+    if category.name == CategoryCurrentName then
+      category.name = newName
+    end
+  end
+  for i,telaportLoc in ipairs(global.TelaportLocations) do
+    for x,category in ipairs(telaportLoc[6]) do
+      if category.name == CategoryCurrentName then
+        category.name = newName
+      end
+    end
+  end
+  setPlayerCategory(player,newName)
+  
+  closeCategorySettingsWindow(player)
+  recreateOpenWindows()
 end
 
 function getNextPosition( Category )
@@ -804,7 +819,8 @@ function createTelaportSetCategoryWindow(gui,categoryPosition, currentCategory)
   return frame
 end
 
-function createTelaportCategoryAddWindow( gui )
+function createTelaportCategoryAddWindow(player)
+  local gui = player.gui.center
   local frame = gui.add({type="frame", name="TelaportCategoryAddWindow", direction="vertical", caption="New Category Name"})
   frame.add({type="textfield", name="TelaportCategoryAddText"})
   frame.TelaportCategoryAddText.text = ""
@@ -813,7 +829,40 @@ function createTelaportCategoryAddWindow( gui )
   flow.add({type="button", name=createButtonName("TelaportCategoryAdd_Cancel"), caption="Cancel"})
   flow.add({type="button", name=createButtonName("TelaportCategoryAdd_OK") , caption="OK"})
 
+  setPlayerWindowOpenNamePrefix(player , "TelaportCategoryAdd")
+  player.opened = frame
   return frame
+end
+
+function closeCategoryAddWindow(player)
+  player.gui.center.TelaportCategoryAddWindow.destroy()
+  setPlayerWindowOpenNamePrefix(player,nil)
+  player.opened = nil
+end
+
+function onCategoryAddConfirm(event)
+  local player = game.players[event.player_index]
+  local frame = player.gui.center.TelaportCategoryAddWindow
+  if frame == nil then
+    player.print("Could not find open window")
+    return
+  end
+
+  local categoryName = frame.TelaportCategoryAddText.text
+  if not(categoryName ~= nil and categoryName ~= '') then
+    --alert that player can not input black string as category name
+    player.print("can't have a blank category name.")
+    return
+  end
+
+  if categoryNameAllreadyExist(categoryName,player) then
+    player.print("A category with the same name already exists")
+    return
+  end
+
+  addCategory(categoryName)
+  recreateOpenWindows()
+  closeCategoryAddWindow(player)
 end
 
 function getPlayerWindowOpenNamePrefix( player )

--- a/control.lua
+++ b/control.lua
@@ -446,6 +446,7 @@ function createTelaPortRenameWindow(player,TelportIndex,oldName)
   local frame = gui.add({type="frame", name="TelaportRenameWindow", direction="vertical", caption="Teleport Location Rename", tags={teleportIndex=TelportIndex}})
   frame.add({type="textfield", name="TelaportRenameText"})
   frame.TelaportRenameText.text = oldName
+  frame.TelaportRenameText.focus()
   
   local flow = frame.add({type="flow", name="TelaportRenameFlow", direction="horizontal"})
   flow.add({type="button", name=createButtonName("TelaportRename_Cancel"), caption="Cancel"})
@@ -732,6 +733,7 @@ function createCategorySettingWindow(player,oldName)
   local frame = gui.add({type="frame", name="TelaportCategorySettingWindow", direction="vertical", caption="Category Settings", tags={oldName=oldName}})
   frame.add({type="textfield", name="TelaportCategorySettingText"})
   frame.TelaportCategorySettingText.text = oldName
+  frame.TelaportCategorySettingText.focus()
 
   local flow = frame.add({type="flow", name="TelaportCategorySettingFlow", direction="horizontal"})
   flow.add({type="button", name=createButtonName("TelaportCategorySetting_Cancel"), caption="Cancel"})
@@ -824,6 +826,7 @@ function createTelaportCategoryAddWindow(player)
   local frame = gui.add({type="frame", name="TelaportCategoryAddWindow", direction="vertical", caption="New Category Name"})
   frame.add({type="textfield", name="TelaportCategoryAddText"})
   frame.TelaportCategoryAddText.text = ""
+  frame.TelaportCategoryAddText.focus()
 
   local flow = frame.add({type="flow", name="TelaportCategoryAddFlow", direction="horizontal"})
   flow.add({type="button", name=createButtonName("TelaportCategoryAdd_Cancel"), caption="Cancel"})


### PR DESCRIPTION
Fixes the confirm and cancel (enter and escape) hotkeys not working for the category add, category settings and teleport rename dialogs.

The name field in each of these dialogs is now focused by default.